### PR TITLE
Slight usabilty improvements and fixes to badly exported gpx files

### DIFF
--- a/runkeeper2endomondo.py
+++ b/runkeeper2endomondo.py
@@ -14,6 +14,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."""
 
 import sys
+import os
 from BeautifulSoup import BeautifulStoneSoup
 import datetime
 import glob
@@ -24,11 +25,12 @@ sportstracker_time_format = "%Y-%m-%dT%H:%M:%S"
 def main():
 
     files = list()
-    
-    all_gpx_files = glob.glob('./*.gpx')
-    
+
+    for endomondo_file in glob.glob('./endomondo*.gpx'):
+        os.remove(endomondo_file)
+
     # To make sure our data files are attached in correct order; we don't trust file system (download order, ...)
-    for ffile in all_gpx_files:
+    for ffile in glob.glob('./*.gpx'):
         ffile = open(ffile, "r")
         filecontent = ffile.read()
         xml = BeautifulStoneSoup(filecontent)
@@ -36,38 +38,52 @@ def main():
         try:
             starttime = datetime.datetime.strptime(trkstart, gpx_time_format)
         except ValueError:
-        	# This deals with Sports Tracker files which have a silly time format
+            # This deals with Sports Tracker files which have a silly time format
             index = trkstart.find('.')
             try:
                 timepart = trkstart[0:index-1]
                 starttime = datetime.datetime.strptime(timepart, sportstracker_time_format)
             except ValueError:
-            # A user has submitted yet another Sports Tracker time format    
+                # A user has submitted yet another Sports Tracker time format
                 timepart = trkstart[0:index]
                 starttime = datetime.datetime.strptime(timepart, sportstracker_time_format)
         files += [[starttime, filecontent]]
-    
-    ffiles = sorted(files, key=lambda *d: d[0]) 
-    
-    # GPX end tag is unnecessary from initial file
-    joined_gpx = ffiles[0][1].split("</gpx>")[0]
-    
-    # "Header" data (initial xml tag, gpx tag, metadata, etc.) is unnecessary
-    # in subsequent file, therefore we remove it, along with end GPX tag.
-    for date, ffile in ffiles[1:]:
-        header, content = ffile.split("<trk>")
-        content = "<trk>" + content
-        joined_gpx += content.split("</gpx>")[0]
-    
-    # Processed all files, append end GPX tag
-    joined_gpx += "</gpx>"
-    
-    # Write out concatenated file
-    output_filename = "endomondo.gpx"
-    output_gpx = file(output_filename, "w")
-    output_gpx.write(joined_gpx)
-    output_gpx.close()
-    
+
+    input_ffiles = sorted(files, key=lambda *d: d[0])
+
+    gpx_files_per_export = 50
+    filecount = 0
+
+    for ffiles in [input_ffiles[i:i+gpx_files_per_export] for i in range(0, len(input_ffiles), gpx_files_per_export)]:
+        # GPX end tag is unnecessary from initial file
+        joined_gpx = ffiles[0][1].split("</gpx>")[0]
+
+        # "Header" data (initial xml tag, gpx tag, metadata, etc.) is unnecessary
+        # in subsequent file, therefore we remove it, along with end GPX tag.
+        for date, ffile in ffiles[1:]:
+            header, content = ffile.split("<trk>")
+            # Handle bug in runkeeper export that doesn't supply closing
+            # </trkseg>
+            if '</trkseg>' not in content:
+                content = content.replace('</trk>', '</trkseg>\n</trk>')
+            # Handle another bug where closing trackseg doesn't exist
+            if "</trkpt>\n<trkseg>" in content:
+                content = content.replace('</trkpt>\n<trkseg>', '</trkpt></trkseg>\n\n<trkseg>')
+
+
+            content = "<trk>" + content
+            joined_gpx += content.split("</gpx>")[0]
+
+        # Processed all files, append end GPX tag
+        joined_gpx += "</gpx>"
+
+        # Write out concatenated file
+        output_filename = "endomondo_%s.gpx" % filecount
+        filecount += 1
+        output_gpx = file(output_filename, "w")
+        output_gpx.write(joined_gpx)
+        output_gpx.close()
+
 if __name__ == '__main__':
     main()
 


### PR DESCRIPTION
- Set a max export size of 50 to reduce file-size
- Remove previous dump files before exporting again
- Fix a number of issues with badly formatted export data from runkeeper. Parsed around 150 entries successfully. 
